### PR TITLE
add: Add continuous integration to create AppImages

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,76 @@
+# (c) Srevin Saju 2020. All rights reserved 
+# Licensed under MIT License
+# Continuous Integration to release configured AppImages for Element (Riot) desktop client
+
+name: Continuous
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  AppImage:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Current Directory Structure
+        run: |
+          ls 
+          git describe --tags --always
+      
+      - name: Build Altus
+        run: |
+          cd src
+          yarn install
+          yarn add electron-builder --dev
+          yarn run electron-builder -l appimage --publish never
+          ls dist
+          mkdir -p dist/appimage
+          mv dist/*.AppImage dist/appimage/.
+          cd dist/appimage
+          ./*.AppImage --appimage-extract
+          wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x ./appimagetool-x86_64.AppImage
+          rm Altus*.AppImage
+          ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run squashfs-root -n -u 'gh-releases-zsync|amanharwara|altus|continuous|Altus*.AppImage.zsync' Altus-`git describe --tags --always`-x86_64.AppImage
+          rm -r ./appimagetool-x86_64.AppImage
+          chmod +x *.AppImage
+          rm -rf squashfs-root
+
+      - name: Upload Appimage
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: altus-continuous-x86_64.AppImage
+          path: 'src/dist/appimage/'
+
+  Release:
+    needs: [AppImage]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [3.8]
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: altus-continuous-x86_64.AppImage
+
+
+    - name: Release
+      uses: marvinpinto/action-automatic-releases@latest
+      if: github.ref == 'refs/heads/master'
+      with:
+        automatic_release_tag: continuous
+        title: Continuous
+        prerelease: false
+        files: |
+          altus-continuous-x86_64.AppImage
+
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+ 


### PR DESCRIPTION
Altus AppImage releases were non-updatable. By providing
updateinformation, it would be possible to update
AppImages using AppImageUpdate or any other AppImageUpdate
provider